### PR TITLE
Support for localized fields in brick.

### DIFF
--- a/src/ConfigElement/Value/DefaultValue.php
+++ b/src/ConfigElement/Value/DefaultValue.php
@@ -15,36 +15,56 @@
 
 namespace OutputDataConfigToolkitBundle\ConfigElement\Value;
 
-
 use OutputDataConfigToolkitBundle\ConfigElement\AbstractConfigElement;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\DefaultMockup;
 use Pimcore\Model\DataObject\AbstractObject;
+use Pimcore\Model\DataObject\Localizedfield;
 
 class DefaultValue extends AbstractConfigElement {
 
     protected $icon;
+    private $localized;
 
     public function __construct($config, $context = null) {
         parent::__construct($config, $context);
         $this->icon = $config->icon;
+        $this->localized = false;
     }
+
 
     public function getLabeledValue($object) {
 
+        $this->localized = false;
         $attributeParts = explode("~", $this->attribute);
         $label = $this->label;
 
         $getter = "get" . ucfirst($this->attribute);
 
+        $brickInfos = null;
         if (substr($this->attribute, 0, 1) == "~") {
             // key value, ignore for now
         } else if(count($attributeParts) > 1) {
             $brickType = $attributeParts[0];
             $brickKey = $attributeParts[1];
 
-            $getter = "get" . ucfirst(\Pimcore\Model\DataObject\Service::getFieldForBrickType($object->getClass(), $brickType));
-            $brickTypeGetter = "get" . ucfirst($brickType);
-            $brickGetter = "get" . ucfirst($brickKey);
+            if ($brickKey && strpos($brickType, '?') === 0) {
+                $definitionJson = substr($brickType, 1);
+                $brickInfos = json_decode($definitionJson);
+                $containerKey = $brickInfos->containerKey;
+                $fieldName = $brickInfos->fieldname;
+                $brickfield = $brickInfos->brickfield;
+
+                $brickType = $containerKey;
+
+                $getter = 'get'.ucfirst($fieldName);
+                $brickTypeGetter = 'get'.ucfirst($brickType);
+                $brickGetter = 'get'.ucfirst($brickfield);
+
+            } else {
+                $getter = "get" . ucfirst(\Pimcore\Model\DataObject\Service::getFieldForBrickType($object->getClass(), $brickType));
+                $brickTypeGetter = "get" . ucfirst($brickType);
+                $brickGetter = "get" . ucfirst($brickKey);
+            }
         }
         if(method_exists($object, $getter) || $object instanceof DefaultMockup) {
             $value = $object->$getter();
@@ -58,6 +78,7 @@ class DefaultValue extends AbstractConfigElement {
                     $lf = $object->getClass()->getFieldDefinition("localizedfields");
                     if($lf) {
                         $def = $lf->getFieldDefinition($this->attribute);
+                        $this->localized = true;
                     }
                 }
 
@@ -68,20 +89,36 @@ class DefaultValue extends AbstractConfigElement {
                 }
 
                 if(!empty($value) && !empty($brickGetter)) {
-                    $def = \Pimcore\Model\DataObject\Objectbrick\Definition::getByKey($brickType);
-                    $def = $def->getFieldDefinition($brickKey);
+                    $brickDef = \Pimcore\Model\DataObject\Objectbrick\Definition::getByKey($brickType);
+                    $def = $brickDef->getFieldDefinition($brickKey);
+                    if(!$def){
+                        /**
+                         * @var \Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields $lf
+                         */
+                        $lf = $brickDef->getFieldDefinition("localizedfields");
+                        if($lf) {
+                            $def = $lf->getFieldDefinition($brickInfos ? $brickfield : $this->attribute);
+                            if ($def) {
+                                $this->localized = true;
+                            }
+                        }
+                    }
+
                     if(empty($label) && !empty($value)) {
                         if($def) {
                             $label = $def->getTitle();
                         }
                     }
 
-
                     if(is_object($value) && method_exists($value, $brickTypeGetter)) {
                         $value = $value->$brickTypeGetter();
 
                         if(is_object($value) && method_exists($value, $brickGetter)) {
                             $value = $value->$brickGetter();
+                        } elseif ($brickInfos) {
+                            $lfs = $value->getLocalizedfields();
+                            $value = $lfs->getLocalizedValue($brickfield);
+                            $this->localized = true;
                         } else {
                             $value = null;
                         }

--- a/src/ConfigElement/Value/DefaultValue.php
+++ b/src/ConfigElement/Value/DefaultValue.php
@@ -78,7 +78,9 @@ class DefaultValue extends AbstractConfigElement {
                     $lf = $object->getClass()->getFieldDefinition("localizedfields");
                     if($lf) {
                         $def = $lf->getFieldDefinition($this->attribute);
-                        $this->localized = true;
+                        if ($def) {
+                            $this->localized = true;
+                        }
                     }
                 }
 

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -223,9 +223,11 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
             } catch(\Exception $e) {
                 Logger::err($e);
             }
+        } else {
+            $def = $objectClass->getFieldDefinition($attributeName);
         }
 
-        if(!$def & !empty($brickType)) {
+        if(!$def && !empty($brickType)) {
             try {
                 $def = \Pimcore\Model\DataObject\Objectbrick\Definition::getByKey($brickType);
                 $def = $def->getFieldDefinition($brickKey);

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -206,10 +206,26 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
             $brickKey = $attributeParts[1];
         }
 
-        $def = $objectClass->getFieldDefinition($attributeName);
+        $def = null;
+        $brickInfos = null;
+        if ($brickKey && strpos($brickType, '?') === 0) {
+            $definitionJson = substr($brickType, 1);
+            $brickInfos = json_decode($definitionJson);
+            $containerKey = $brickInfos->containerKey;
+            $fieldName = $brickInfos->fieldname;
+            $brickfield = $brickInfos->brickfield;
+            try {
+                $brickDef = \Pimcore\Model\DataObject\Objectbrick\Definition::getByKey($containerKey);
+                $def = $brickDef->getFieldDefinition($brickKey);
+                if(empty($def) && $brickDef->getFieldDefinition("localizedfields")) {
+                    $def = $brickDef->getFieldDefinition("localizedfields")->getFieldDefinition($brickfield);
+                }
+            } catch(\Exception $e) {
+                Logger::err($e);
+            }
+        }
 
-
-        if(!empty($brickType)) {
+        if(!$def & !empty($brickType)) {
             try {
                 $def = \Pimcore\Model\DataObject\Objectbrick\Definition::getByKey($brickType);
                 $def = $def->getFieldDefinition($brickKey);

--- a/src/Service.php
+++ b/src/Service.php
@@ -63,7 +63,7 @@ class Service {
         return $config;
     }
 
-    private static function locateOperatorConfigClass($configElement) : string {
+    private static function locateOperatorConfigClass($configElement) {
         $namespaces = [
             "\\OutputDataConfigToolkitBundle\\ConfigElement\\Operator\\",
             "\\AppBundle\\OutputDataConfigToolkit\\ConfigElement\\Operator\\"

--- a/src/Service.php
+++ b/src/Service.php
@@ -63,7 +63,7 @@ class Service {
         return $config;
     }
 
-    private static function locateOperatorConfigClass($configElement) {
+    private static function locateOperatorConfigClass($configElement) : string {
         $namespaces = [
             "\\OutputDataConfigToolkitBundle\\ConfigElement\\Operator\\",
             "\\AppBundle\\OutputDataConfigToolkit\\ConfigElement\\Operator\\"


### PR DESCRIPTION
* Correctly add localized fields in brick in configuration tree.
* Correctly interpret localized fields in brick in DefaultValue element.
* Provide possiblity to ask if default value is in relation with a localized field (helps users to decide if output still needs to be translated, or is already translated).