### PR TITLE
Restore custom icon on default value after updates.

### DIFF
--- a/src/Resources/public/js/OutputDataConfigDialog.js
+++ b/src/Resources/public/js/OutputDataConfigDialog.js
@@ -259,7 +259,7 @@ pimcore.bundle.outputDataConfigToolkit.OutputDataConfigDialog = Class.create(pim
                         treenode.expandable = true;
                     }
                 }
-                if (configuration[i].icon != null) {
+                if (configuration[i].icon != null && configuration[i].icon.length > 0) {
                     treenode.iconCls = null;
                     treenode.icon = configuration[i].icon;
                 }

--- a/src/Resources/public/js/outputDataConfigElements/value/DefaultValue.js
+++ b/src/Resources/public/js/outputDataConfigElements/value/DefaultValue.js
@@ -129,8 +129,19 @@ pimcore.bundle.outputDataConfigToolkit.outputDataConfigElements.value.DefaultVal
         } else {
             this.node.data.configAttributes.label = null;
         }
-        this.node.data.configAttributes.icon = this.icon ? this.icon.getValue() : null;
-        this.node.set('icon', this.icon ? this.icon.getValue() : null);
+
+        var iconValue = this.icon ? this.icon.getValue() : null;
+        if (iconValue != null && iconValue.length == 0) {
+            iconValue = null;
+            this.node.data.configAttributes.icon = iconValue;
+            var restoredIconClass = "pimcore_icon_" + this.node.data.configAttributes.dataType;
+            this.node.set('iconCls', restoredIconClass);
+        } else if (iconValue != null) {
+            this.node.set('iconCls', null);
+        }
+        this.node.data.configAttributes.icon = iconValue;
+        this.node.set('icon', iconValue);
+
         this.window.close();
     }
 });


### PR DESCRIPTION
- Show icon properly when a custom icon is not used.
- Visualize icon correctly in configuration tree after changes.