### PR TITLE
updated for pimcore 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ pimcore.bundle.outputDataConfigToolkit.outputDataConfigElements.operator.RemoveZ
 });
 ```
 
+## Running with Pimcore < 5.4
+With Pimcore 5.4 the location of static Pimcore files like icons has changed. In order to make this bundle work 
+with Pimcore < 5.4, please add following rewrite rule to your `.htaccess`.
+```
+    # rewrite rule for pre pimcore 5.4 core static files
+    RewriteRule ^bundles/pimcoreadmin/(.*) /pimcore/static6/$1 [PT,L]
+``` 
+
+
 ## Migration from Pimcore 4
 - Change table name from `plugin_outputdataconfigtoolkit_outputdefinition` to 
 `bundle_outputdataconfigtoolkit_outputdefinition`.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "license": "GPL-3.0+",
   "type": "pimcore-bundle",
   "require": {
-    "pimcore/core-version": ">=5.2.0 <5.4"
+    "pimcore/core-version": ">=5.2.0 <5.5"
   },
   "autoload": {
     "psr-4": {

--- a/src/Resources/public/css/admin.css
+++ b/src/Resources/public/css/admin.css
@@ -13,13 +13,13 @@
 
 
 .pimcore_icon_operator_group {
-    background: url("/pimcore/static6/img/flat-color-icons/multiple_inputs.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/multiple_inputs.svg") center center no-repeat !important;
 }
 .pimcore_icon_operator_concatenator {
-    background: url("/pimcore/static6/img/flat-color-icons/capacitor.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/capacitor.svg") center center no-repeat !important;
 }
 .bundle_outputdataconfig_icon {
-    background: url("/pimcore/static6/img/flat-color-icons/grid.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/grid.svg") center center no-repeat !important;
 }
 .bundle_outputdataconfig_icon:before {
     position: absolute;
@@ -28,32 +28,32 @@
     bottom: 0px;
     right: 0px;
     content: "";
-    background: url(/pimcore/static6/img/flat-color-icons/go.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/go.svg) center center no-repeat !important;
 }
 
 
 
 
 .pimcore_icon_operator_text {
-    background: url("/pimcore/static6/img/flat-color-icons/text.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/text.svg") center center no-repeat !important;
 }
 
 .pimcore_icon_operator_table {
-    background: url("/pimcore/static6/img/flat-color-icons/data_sheet.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/data_sheet.svg") center center no-repeat !important;
 }
 
 .pimcore_icon_operator_tablerow {
-    background: url("/pimcore/static6/img/flat-color-icons/table-row.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/table-row.svg") center center no-repeat !important;
 }
 
 .pimcore_icon_operator_tablecol {
-    background: url("/pimcore/static6/img/flat-color-icons/table-column.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/table-column.svg") center center no-repeat !important;
 }
 
 .pimcore_icon_operator_cell_formater {
-    background: url("/pimcore/static6/img/icon/style_edit.png") no-repeat scroll left center transparent !important;
+    background: url("/bundles/pimcoreadmin/img/icon/style_edit.png") no-repeat scroll left center transparent !important;
 }
 
 .pimcore_icon_operator_textaddon {
-    background: url("/pimcore/static6/img/icon/font_add.png") no-repeat scroll left center transparent !important;
+    background: url("/bundles/pimcoreadmin/img/icon/font_add.png") no-repeat scroll left center transparent !important;
 }

--- a/src/Resources/public/js/OutputDataConfigTab.js
+++ b/src/Resources/public/js/OutputDataConfigTab.js
@@ -100,7 +100,7 @@ pimcore.bundle.outputDataConfigToolkit.Tab = Class.create({
             items: [
                 {
                     tooltip: t('overwrite/edit'),
-                    icon: "/pimcore/static6/img/flat-color-icons/edit.svg",
+                    icon: "/bundles/pimcoreadmin/img/flat-color-icons/edit.svg",
                     handler: function (grid, rowIndex) {
                         var data = grid.getStore().getAt(rowIndex);
                         this.openConfigDialog(data.data.id);
@@ -115,7 +115,7 @@ pimcore.bundle.outputDataConfigToolkit.Tab = Class.create({
             items: [
                 {
                     tooltip: t('reset'),
-                    icon: "/pimcore/static6/img/flat-color-icons/delete.svg",
+                    icon: "/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",
                     getClass: function(v, meta, rec) {  // Or return a class from a function
                         if(rec.get('is_inherited') || this.object.id == 1) {
                             return "pimcore_hidden";

--- a/src/Resources/public/js/outputDataConfigElements/value/KeyValue.js
+++ b/src/Resources/public/js/outputDataConfigElements/value/KeyValue.js
@@ -94,7 +94,7 @@ pimcore.bundle.outputDataConfigToolkit.outputDataConfigElements.value.KeyValue =
                     items:[
                         {
                             tooltip:t('up'),
-                            icon:"/pimcore/static6/img/flat-color-icons/up.svg",
+                            icon:"/bundles/pimcoreadmin/img/flat-color-icons/up.svg",
                             handler:function (grid, rowIndex) {
                                 if (rowIndex > 0) {
                                     var rec = grid.getStore().getAt(rowIndex);
@@ -111,7 +111,7 @@ pimcore.bundle.outputDataConfigToolkit.outputDataConfigElements.value.KeyValue =
                     items:[
                         {
                             tooltip:t('down'),
-                            icon:"/pimcore/static6/img/flat-color-icons/down.svg",
+                            icon:"/bundles/pimcoreadmin/img/flat-color-icons/down.svg",
                             handler:function (grid, rowIndex) {
                                 if (rowIndex < (grid.getStore().getCount() - 1)) {
                                     var rec = grid.getStore().getAt(rowIndex);
@@ -128,7 +128,7 @@ pimcore.bundle.outputDataConfigToolkit.outputDataConfigElements.value.KeyValue =
                     items: [
                         {
                             tooltip: t('remove'),
-                            icon: "/pimcore/static6/img/flat-color-icons/delete.svg",
+                            icon: "/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",
                             handler: function (grid, rowIndex) {
                                 grid.getStore().removeAt(rowIndex);
                             }.bind(this)


### PR DESCRIPTION
## For running with Pimcore < 5.4
With Pimcore 5.4 the location of static Pimcore files like icons has changed. In order to make this bundle work with Pimcore < 5.4, please add following rewrite rule to your `.htaccess`.
```
    # rewrite rule for pre pimcore 5.4 core static files
    RewriteRule ^bundles/pimcoreadmin/(.*) /pimcore/static6/$1 [PT,L]
``` 