### PR TITLE
Bugfix when used in combination with localized fields in bricks

### DIFF
--- a/src/ConfigElement/Value/DefaultValue.php
+++ b/src/ConfigElement/Value/DefaultValue.php
@@ -117,7 +117,7 @@ class DefaultValue extends AbstractConfigElement {
 
                         if(is_object($value) && method_exists($value, $brickGetter)) {
                             $value = $value->$brickGetter();
-                        } elseif ($brickInfos) {
+                        } elseif ($brickInfos && !is_null($value)) {
                             $lfs = $value->getLocalizedfields();
                             $value = $lfs->getLocalizedValue($brickfield);
                             $this->localized = true;


### PR DESCRIPTION
If the value is empty here, an exception might occur. With this fix it works like expected.