### PR TITLE
Removed Old Namespaces in TableRow and TableCol Operator

### DIFF
--- a/src/ConfigElement/Operator/TableCol.php
+++ b/src/ConfigElement/Operator/TableCol.php
@@ -36,7 +36,7 @@ class TableCol extends AbstractOperator {
             $value->colSpan = $this->colspan;
             $value->headline = $this->headline;
 
-            if(empty($value) || $childs[0] instanceof \Elements\OutputDataConfigToolkit\ConfigElement\Operator\Text) {
+            if(empty($value) || $childs[0] instanceof \OutputDataConfigToolkitBundle\ConfigElement\Operator\Text) {
                 $value->empty = true;
             }            
         }

--- a/src/ConfigElement/Operator/TableRow.php
+++ b/src/ConfigElement/Operator/TableRow.php
@@ -34,7 +34,7 @@ class TableRow extends AbstractOperator {
         foreach($childs as $c) {
 
             $col = $c->getLabeledValue($object);
-            if(!empty($col) && (!$col->empty && !($c instanceof \Elements\OutputDataConfigToolkit\ConfigElement\Operator\Text))) {
+            if(!empty($col) && (!$col->empty && !($c instanceof \OutputDataConfigToolkitBundle\ConfigElement\Operator\Text))) {
                 $isEmpty = false;
             }
             $valueArray[] = $c->getLabeledValue($object);


### PR DESCRIPTION
This PR simply removes two old namespaces from the TableRow and TableCol operators.

The old namespaces might not break the code in various situations, but will produce a wrong "isEmpty" result on the labeled value as the if is not working correclty when traversing the children.