### PR TITLE
Fixed exception if quantity value has no unit

### DIFF
--- a/src/ConfigElement/Value/DimensionUnitField.php
+++ b/src/ConfigElement/Value/DimensionUnitField.php
@@ -55,7 +55,7 @@ class DimensionUnitField extends DefaultValue {
                     if(is_numeric($value)) {
                         $value = $formatter->formatNumber($value);
                     }
-                    $result->value = $value . " " . $rawResult->value->getUnit()->getAbbreviation();
+                    $result->value = $value . ($rawResult->value->getUnit() ? " " . $rawResult->value->getUnit()->getAbbreviation() : "");
                 }
             }
 


### PR DESCRIPTION
The DimensionUnitField raised an exception if the quantity value has no unit set and the abbreviation is tried to being accessed. Only show it if there is a valid unit available.