### PR TITLE
Fix classificationstore add-all functionality

### DIFF
--- a/src/Resources/public/js/OutputDataConfigDialog.js
+++ b/src/Resources/public/js/OutputDataConfigDialog.js
@@ -341,13 +341,15 @@ pimcore.bundle.outputDataConfigToolkit.OutputDataConfigDialog = Class.create(pim
                         text: t("add_all"),
                         iconCls: "pimcore_icon_add",
                         handler: function (item, e) {
-                            Ext.Array.forEach(record.childNodes, function (child) {
-                                child.data.configAttributes = {
-                                    label: null,
-                                    icon: child.data.iconCls,
-                                    dataType: child.data.dataType,
-                                };
-                                this.selectionPanel.getRootNode().appendChild(child);
+                            Ext.Array.forEach(record.childNodes, function (record) {
+                                var attr = record.data;
+                                if(record.data.configAttributes) {
+                                    attr = record.data.configAttributes;
+                                }
+                                var element = this.getConfigElement(attr);
+                                var copy = element.getCopyNode(record);
+                                copy.data.configAttributes.icon = null;
+                                this.selectionPanel.getRootNode().appendChild(copy);
                             }, this);
                         }.bind(this),
                     }]


### PR DESCRIPTION
# Bugfix

The "add-all" functionality in the context menu produced invalid config data, which were shown as empty lines in the right side of the config panel. The behavior is now similar to a doubleclick on any item and selecting no custom options in the dialog window.

![image](https://user-images.githubusercontent.com/9052094/64604922-5898c080-d3c3-11e9-8db2-b0d861f92ed2.png)
