### PR TITLE
Fix classification display mode bug

### DIFF
--- a/src/Controller/ClassController.php
+++ b/src/Controller/ClassController.php
@@ -121,10 +121,13 @@ class ClassController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
 
             if (($targetObject = DataObject\Concrete::getById($targetObjectId)) && !$targetObject instanceof DataObject\Folder) {
                 $class->setFieldDefinitions($fieldDefinitions);
-                DataObject\Service::enrichLayoutDefinition($result['objectColumns']['childs'][0], $targetObject);
+                
                 try {
-                    // todo: is there a better way to check if a classification group is assigned to the class?
+                    // @todo: is there a better way to check if a classification group is assigned to the class?
                     $enrichment = Db::get()->fetchOne("SELECT EXISTS (SELECT * FROM object_classificationstore_groups_{$class->getId()} WHERE o_id = '{$targetObjectId}')");
+                    if($enrichment){
+                        DataObject\Service::enrichLayoutDefinition($result['objectColumns']['childs'][0], $targetObject);
+                    }
                 } catch (TableNotFoundException $exception) {
                     $enrichment = false;
                 }


### PR DESCRIPTION
# Bugfix

If the classification store display mode is set to object or relevant, the OutputDataConfigDialog will show an error if a channel for an object is selected which has no classification store.

I.e. If I have the following scenario: 
- ProductCategory class which does not have a classification store field 
- Product class which does have a classification store field (let's say it's `attributes`).
If I then open a ProductCategory object, go to the OutputChannel Tab and then try to open a channel for the Product class, I get an error that the Getter (`getAttributes()`) for the classificationStore field of the Product class is not available in the ProductCategory instance - obviously.