### PR TITLE
Introduce init event for output config tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An output data configuration consists of
 
 #### Table of Contents
 
-- [Channel Config](#channel-config)  
+- [Configuration](#configuration)  
 - [Defining output data configuration for different output channels](#defining-output-data-configuration-for-different-output-channels) 
 - [Working with output channels in code](#working-with-output-channels-in-code) 
 - [Events](#events)  

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ app.templating.helper.productDetailSpecification:
 ### used by projects for example
 - E-Commerce-Demo (http://ecommercedemo.pimcore.org)
 
+## Events
+| Event        | Example           | Description |
+| :------------- | :-----| : ---|
+| outputDataConfigToolkit.initialize | [OutputDataConfigToolkitListener](doc/OutputDataConfigToolkitListener.php) | Is thrown before any output-config tab's initialization, so you can i.e. manipulate the configuration object, or only show the tab for a specific class type. |
+
+
 ## Adding new operators
 Create a Pimcore bundle and add following files:
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ app.templating.helper.productDetailSpecification:
 - E-Commerce-Demo (http://ecommercedemo.pimcore.org)
 
 ## Events
-| Event        | Example           | Description |
-| :------------- | :-----| : ---|
-| outputDataConfigToolkit.initialize | [OutputDataConfigToolkitListener](doc/OutputDataConfigToolkitListener.php) | Is thrown before any output-config tab's initialization, so you can i.e. manipulate the configuration object, or only show the tab for a specific class type. |
+| Event | Description |
+| ----- | ----------- |
+| `outputDataConfigToolkit.initialize` | Before any output-config tab's initialization, so you can i.e. manipulate the configuration object, or only show the tab for a specific class type. For a full example see [OutputDataConfigToolkitListener](doc/OutputDataConfigToolkitListener.php). |
 
 
 ## Adding new operators

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ An output data configuration consists of
 - values = data object attributes
 - operators = can combine, modify, calculate, ... values
 
+#### Table of Contents
+
+- [Channel Config](#channel-config)  
+- [Defining output data configuration for different output channels](#defining-output-data-configuration-for-different-output-channels) 
+- [Working with output channels in code](#working-with-output-channels-in-code) 
+- [Events](#events)  
+- [Adding new operators](#adding-new-operators)  
+- [Defining output data configuration programmatically](#defining-output-data-configuration-programmatically)  
+- [Running with Pimcore < 5.4](#running-with-pimcore--54)  
+- [Migration from Pimcore 4](#migration-from-pimcore-4)  
+
 ## Configuration
 
 ### Channel Config

--- a/doc/OutputDataConfigToolkitListener.php
+++ b/doc/OutputDataConfigToolkitListener.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * User: jraab
+ * Date: 01.10.2019
+ * Time: 17:32
+ */
+
+namespace AppBundle\EventListener;
+
+use OutputDataConfigToolkitBundle\Event\InitializeEvent;
+use OutputDataConfigToolkitBundle\Event\OutputDataConfigToolkitEvents;
+use Pimcore\Model\DataObject\Folder;
+use Pimcore\Model\DataObject\Product;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class OutputDataConfigToolkitListener
+ * @package AppBundle\EventListener
+ */
+class OutputDataConfigToolkitListener implements EventSubscriberInterface
+{
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            OutputDataConfigToolkitEvents::INITIALIZE => "onInitialize"
+        ];
+    }
+
+    /**
+     * Manipulate outputdataconfigtoolkit initialization
+     *      - only show output config tab for product objects
+     *      - always use product root
+     *
+     * @param InitializeEvent $event
+     */
+    public function onInitialize(InitializeEvent $event)
+    {
+        $object = $event->getObject();
+        if ($object->getClassName() != substr(strrchr(Product::class, "\\"), 1)) {
+            $event->setHideConfigTab(true);
+        } else {
+            while (
+                $object->getParentId() != 1
+                && !$object->getParent() instanceof Folder
+                && ($object = $object->getParent())
+            );
+        }
+        $event->setObject($object);
+    }
+}

--- a/doc/OutputDataConfigToolkitListener.php
+++ b/doc/OutputDataConfigToolkitListener.php
@@ -1,8 +1,15 @@
 <?php
 /**
- * User: jraab
- * Date: 01.10.2019
- * Time: 17:32
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
  */
 
 namespace AppBundle\EventListener;

--- a/doc/OutputDataConfigToolkitListener.php
+++ b/doc/OutputDataConfigToolkitListener.php
@@ -9,6 +9,7 @@ namespace AppBundle\EventListener;
 
 use OutputDataConfigToolkitBundle\Event\InitializeEvent;
 use OutputDataConfigToolkitBundle\Event\OutputDataConfigToolkitEvents;
+use Pimcore\Model\DataObject\Concrete;
 use Pimcore\Model\DataObject\Folder;
 use Pimcore\Model\DataObject\Product;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -37,7 +38,7 @@ class OutputDataConfigToolkitListener implements EventSubscriberInterface
     public function onInitialize(InitializeEvent $event)
     {
         $object = $event->getObject();
-        if ($object->getClassName() != substr(strrchr(Product::class, "\\"), 1)) {
+        if (!$object instanceof Concrete || $object->getClassName() != substr(strrchr(Product::class, "\\"), 1)) {
             $event->setHideConfigTab(true);
         } else {
             while (

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -23,7 +23,6 @@ use Pimcore\Logger;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\Classificationstore\KeyConfig;
-use Pimcore\Model\DataObject\Product;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -15,6 +15,8 @@
 
 namespace OutputDataConfigToolkitBundle\Controller;
 
+use OutputDataConfigToolkitBundle\Event\InitializeEvent;
+use OutputDataConfigToolkitBundle\Event\OutputDataConfigToolkitEvents;
 use OutputDataConfigToolkitBundle\OutputDefinition;
 use OutputDataConfigToolkitBundle\Service;
 use Pimcore\Logger;
@@ -37,6 +39,35 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
 
     /* @var bool $orderByName */
     private $orderByName = false;
+
+    /**
+     * @param Request $request
+     * @return \Pimcore\Bundle\AdminBundle\HttpFoundation\JsonResponse
+     *
+     * @Route("/initialize")
+     */
+    public function initializeAction(Request $request)
+    {
+        $objectId = $request->get("id");
+        $object = AbstractObject::getById($objectId);
+        $eventDispatcher = \Pimcore::getEventDispatcher();
+
+        if (!$object) {
+            $this->adminJson(array("error" => true, "object" => (object)[]));
+        }
+
+        $event = new InitializeEvent($object);
+        $eventDispatcher->dispatch(OutputDataConfigToolkitEvents::INITIALIZE, $event);
+
+        if ($event->getHideConfigTab() || !$event->getObject()) {
+            // do not show output config tab
+            return $this->adminJson(array("success" => true, "object" => false));
+        }
+
+        $data = ["id" => $event->getObject()->getId()];
+
+        return $this->adminJson(array("success" => true, "object" => $data));
+    }
 
     /**
      * @param Request $request

--- a/src/Event/InitializeEvent.php
+++ b/src/Event/InitializeEvent.php
@@ -1,14 +1,27 @@
 <?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
 
 namespace OutputDataConfigToolkitBundle\Event;
 
 
 use Pimcore\Model\DataObject\Concrete;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Class ObjectEvent
  */
-class InitializeEvent extends \Symfony\Component\EventDispatcher\Event
+class InitializeEvent extends Event
 {
     /**
      * @var Concrete
@@ -18,7 +31,7 @@ class InitializeEvent extends \Symfony\Component\EventDispatcher\Event
     /**
      * @var bool
      */
-    private $doNotShowConfigTab;
+    private $hideConfigTab;
 
     /**
      * ObjectEvent constructor.
@@ -27,7 +40,7 @@ class InitializeEvent extends \Symfony\Component\EventDispatcher\Event
     public function __construct(Concrete $object)
     {
         $this->object = $object;
-        $this->doNotShowConfigTab = false;
+        $this->hideConfigTab = false;
     }
 
     /**
@@ -40,7 +53,7 @@ class InitializeEvent extends \Symfony\Component\EventDispatcher\Event
 
     /**
      * @param Concrete $object
-     * @return ObjectEvent
+     * @return InitializeEvent
      */
     public function setObject(Concrete $object): self
     {
@@ -51,18 +64,18 @@ class InitializeEvent extends \Symfony\Component\EventDispatcher\Event
     /**
      * @return bool
      */
-    public function getDoNotShowConfigTab(): bool
+    public function getHideConfigTab(): bool
     {
-        return $this->doNotShowConfigTab;
+        return $this->hideConfigTab;
     }
 
     /**
-     * @param bool $doAbortInitialization
-     * @return Initialize
+     * @param bool $hideConfigTab
+     * @return InitializeEvent
      */
-    public function setDoNotShowConfigTab(bool $doNotShowConfigTab): self
+    public function setHideConfigTab(bool $hideConfigTab): self
     {
-        $this->doNotShowConfigTab = $doNotShowConfigTab;
+        $this->hideConfigTab = $hideConfigTab;
         return $this;
     }
 

--- a/src/Event/InitializeEvent.php
+++ b/src/Event/InitializeEvent.php
@@ -15,6 +15,7 @@
 namespace OutputDataConfigToolkitBundle\Event;
 
 
+use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\Concrete;
 use Symfony\Component\EventDispatcher\Event;
 
@@ -35,27 +36,27 @@ class InitializeEvent extends Event
 
     /**
      * ObjectEvent constructor.
-     * @param Concrete $object
+     * @param AbstractObject $object
      */
-    public function __construct(Concrete $object)
+    public function __construct(AbstractObject $object)
     {
         $this->object = $object;
         $this->hideConfigTab = false;
     }
 
     /**
-     * @return Concrete
+     * @return AbstractObject
      */
-    public function getObject(): Concrete
+    public function getObject(): AbstractObject
     {
         return $this->object;
     }
 
     /**
-     * @param Concrete $object
+     * @param AbstractObject $object
      * @return InitializeEvent
      */
-    public function setObject(Concrete $object): self
+    public function setObject(AbstractObject $object): self
     {
         $this->object = $object;
         return $this;

--- a/src/Event/InitializeEvent.php
+++ b/src/Event/InitializeEvent.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace OutputDataConfigToolkitBundle\Event;
+
+
+use Pimcore\Model\DataObject\Concrete;
+
+/**
+ * Class ObjectEvent
+ */
+class InitializeEvent extends \Symfony\Component\EventDispatcher\Event
+{
+    /**
+     * @var Concrete
+     */
+    private $object;
+
+    /**
+     * @var bool
+     */
+    private $doNotShowConfigTab;
+
+    /**
+     * ObjectEvent constructor.
+     * @param Concrete $object
+     */
+    public function __construct(Concrete $object)
+    {
+        $this->object = $object;
+        $this->doNotShowConfigTab = false;
+    }
+
+    /**
+     * @return Concrete
+     */
+    public function getObject(): Concrete
+    {
+        return $this->object;
+    }
+
+    /**
+     * @param Concrete $object
+     * @return ObjectEvent
+     */
+    public function setObject(Concrete $object): self
+    {
+        $this->object = $object;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getDoNotShowConfigTab(): bool
+    {
+        return $this->doNotShowConfigTab;
+    }
+
+    /**
+     * @param bool $doAbortInitialization
+     * @return Initialize
+     */
+    public function setDoNotShowConfigTab(bool $doNotShowConfigTab): self
+    {
+        $this->doNotShowConfigTab = $doNotShowConfigTab;
+        return $this;
+    }
+
+}

--- a/src/Event/OutputDataConfigToolkitEvents.php
+++ b/src/Event/OutputDataConfigToolkitEvents.php
@@ -21,5 +21,11 @@ namespace OutputDataConfigToolkitBundle\Event;
  */
 class OutputDataConfigToolkitEvents
 {
+
+    /**
+     * @Event("OutputDataConfigToolkitBundle\Event\InitializeEvent")
+     *
+     * @var string
+     */
     const INITIALIZE = "outputDataConfigToolkit.initialize";
 }

--- a/src/Event/OutputDataConfigToolkitEvents.php
+++ b/src/Event/OutputDataConfigToolkitEvents.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace OutputDataConfigToolkitBundle\Event;
+
+
+/**
+ * Class OutputDataConfigToolkitEvents
+ * @package OutputDataConfigToolkitBundle\Controller
+ */
+class OutputDataConfigToolkitEvents
+{
+    const INITIALIZE = "outputDataConfigToolkit.initialize";
+}

--- a/src/Event/OutputDataConfigToolkitEvents.php
+++ b/src/Event/OutputDataConfigToolkitEvents.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
 
 namespace OutputDataConfigToolkitBundle\Event;
 

--- a/src/Resources/public/js/Bundle.js
+++ b/src/Resources/public/js/Bundle.js
@@ -44,8 +44,9 @@ pimcore.bundle.outputDataConfigToolkit.Bundle = Class.create(pimcore.plugin.admi
                         return;
                     }
 
-                    if (data.object.id && data.object.id != object.id) {
-                        var objectData = data.object;
+                    var objectData = object;
+                    if (data.object.id) {
+                        objectData = data.object;
                     }
 
                     var configTab = new pimcore.bundle.outputDataConfigToolkit.Tab(objectData, type);

--- a/src/Resources/public/js/Bundle.js
+++ b/src/Resources/public/js/Bundle.js
@@ -29,11 +29,32 @@ pimcore.bundle.outputDataConfigToolkit.Bundle = Class.create(pimcore.plugin.admi
         
     },
 
-    postOpenObject: function(object, type) {
-        if(pimcore.globalmanager.get("user").isAllowed("bundle_outputDataConfigToolkit")) {
-            var configTab = new pimcore.bundle.outputDataConfigToolkit.Tab(object, type);
-            object.tab.items.items[1].insert(object.tab.items.items[1].items.length, configTab.getLayout());
-            pimcore.layout.refresh();
+    postOpenObject: function (object, type) {
+        if (pimcore.globalmanager.get("user").isAllowed("bundle_outputDataConfigToolkit")) {
+            Ext.Ajax.request({
+                url: "/admin/outputdataconfig/admin/initialize",
+                params: {
+                    id: object.id
+                }
+            })
+                .then(function (res) {
+                    var data = JSON.parse(res.responseText);
+
+                    if (!data.success || data.object === false) {
+                        return;
+                    }
+
+                    if (data.object.id && data.object.id != object.id) {
+                        var objectData = data.object;
+                    }
+
+                    var configTab = new pimcore.bundle.outputDataConfigToolkit.Tab(objectData, type);
+                    var objectTabPanel = object.tab.items.items[1];
+
+                    objectTabPanel.insert(objectTabPanel.items.length, configTab.getLayout());
+                    pimcore.layout.refresh();
+
+                }.bind(this));
         }
     }
 });

--- a/src/Resources/public/js/OutputDataConfigTab.js
+++ b/src/Resources/public/js/OutputDataConfigTab.js
@@ -55,7 +55,11 @@ pimcore.bundle.outputDataConfigToolkit.Tab = Class.create({
                 layout: "fit",
                 iconCls: "bundle_outputdataconfig_icon_material pimcore_material_icon",
                 tbar: toolbarConfig,
-                items: [this.getGrid()]
+                listeners: {
+                    afterrender: function(){
+                        this.layout.insert(this.layout.items.length, this.getGrid());
+                    }.bind(this)
+                }
             });
         }
         return this.layout;


### PR DESCRIPTION
# Introduce init event for output config tab

## Main changes:
- Do not load config data on object open, but on config tab open
- Send init request on object open and within the respective server side action dispatch an initialize event, which allows to hide the tab, or change the target object.
- Add docs and example listener to readme
- Add table of contents to docs

## Use Cases:
- Only activate output config tab for specific class type (i.e. Product).
- Always configure output config on a specific product instance (i.e. the root object) no matter which object is opened