### PR TITLE
Add event to enable sorting / modification of channel attributes on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ app.templating.helper.productDetailSpecification:
 | Event | Description |
 | ----- | ----------- |
 | `outputDataConfigToolkit.initialize` | Before any output-config tab's initialization, so you can i.e. manipulate the configuration object, or only show the tab for a specific class type. For a full example see [OutputDataConfigToolkitListener](doc/OutputDataConfigToolkitListener.php). |
+| `outputDataConfigToolkit.saveEvent`  | Before a specific output config is saved. Can be implemented to sort config attributes or to modify attributes in any other way. |
 
 
 ## Adding new operators

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -396,7 +396,7 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
             $event = new SaveConfigEvent($config);
             $eventDispatcher->dispatch(OutputDataConfigToolkitEvents::SAVE_CONFIG_EVENT, $event);
 
-            if ($event->isSortAttributes()) {
+            if ($event->doSortAttributes()) {
                 $objectClass = ClassDefinition::getById($config->getO_ClassId());
                 $configuration = json_decode($configJson);
                 $configuration = $this->doGetAttributeLabels($configuration, $objectClass, true);

--- a/src/Event/OutputDataConfigToolkitEvents.php
+++ b/src/Event/OutputDataConfigToolkitEvents.php
@@ -28,4 +28,11 @@ class OutputDataConfigToolkitEvents
      * @var string
      */
     const INITIALIZE = "outputDataConfigToolkit.initialize";
+
+    /**
+     * @Event("OutputDataConfigToolkitBundle\Event\SaveConfigEvent")
+     *
+     * @var string
+     */
+    const SAVE_CONFIG_EVENT = "outputDataConfigToolkit.saveEvent";
 }

--- a/src/Event/SaveConfigEvent.php
+++ b/src/Event/SaveConfigEvent.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace OutputDataConfigToolkitBundle\Event;
+
+
+use OutputDataConfigToolkitBundle\OutputDefinition;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class SaveConfigEvent
+ */
+class SaveConfigEvent extends Event
+{
+    private $config;
+
+    private $sortAttributes = false;
+
+    public function __construct(OutputDefinition $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSortAttributes(): bool
+    {
+        return $this->sortAttributes;
+    }
+
+    /**
+     * @param bool $sortAttributes
+     * @return SaveConfigEvent
+     */
+    public function setSortAttributes(bool $sortAttributes): SaveConfigEvent
+    {
+        $this->sortAttributes = $sortAttributes;
+        return $this;
+    }
+
+}

--- a/src/Event/SaveConfigEvent.php
+++ b/src/Event/SaveConfigEvent.php
@@ -35,7 +35,7 @@ class SaveConfigEvent extends Event
     /**
      * @return bool
      */
-    public function isSortAttributes(): bool
+    public function doSortAttributes(): bool
     {
         return $this->sortAttributes;
     }


### PR DESCRIPTION
For large amounts of attributes (e.g., classification store attributes) it can be useful to modify the added attributes before saving the output channel definition.

This PR adds a ``SaveConfigEvent`` which is fired on save of a output definition. It allows to modifiy the configuration directly, or set a flag so that attributes are sorted on save.