### PR TITLE
Repoint static analysis to reusable-static-analysis-unified

### DIFF
--- a/.github/workflows/php-style.yml
+++ b/.github/workflows/php-style.yml
@@ -7,7 +7,7 @@ on:
             - "[0-9]+.x"
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
 

--- a/.github/workflows/php-style.yml
+++ b/.github/workflows/php-style.yml
@@ -1,6 +1,15 @@
 name: PHP Style
 
-on: [push]
+on:
+    push:
+        branches:
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    cancel-in-progress: true
+
 
 jobs:
     php-cs-fixer:

--- a/.github/workflows/php-style.yml
+++ b/.github/workflows/php-style.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
     php-cs-fixer:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             - uses: actions/checkout@v2
               with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,86 +1,95 @@
 name: "Static analysis centralised"
 
 on:
-  schedule:
-    - cron: '0 3 * * 1,3,5'
-  workflow_dispatch:
-  pull_request:
-    types: [ opened, synchronize, reopened ]
-    paths-ignore:
-      - 'doc/**'
-      - 'src/Resources/public/**'
-      - '**.md'
-  push:
-    paths-ignore:
-      - 'doc/**'
-      - 'src/Resources/public/**'
-      - '**.md'
-    branches:
-      - "[0-9]+.[0-9]+"
-      - "[0-9]+.x"
+    schedule:
+        -   cron: '0 3 * * 1,3,5'
+    workflow_dispatch:
+    push:
+        branches:
+            - "[0-9]+.[0-9]+"
+            - "[0-9]+.x"
+            - "feature-*"
+    pull_request:
+        types: [ opened, synchronize, reopened ]
+
 
 env:
-  PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
-  PRIVATE_REPO: ${{ github.event.repository.private }}
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+    PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
+    PRIVATE_REPO: ${{ github.event.repository.private }}
 
 jobs:
-  setup-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
-      phpstan_matrix: ${{ steps.set-matrix.outputs.phpstan_matrix }}
-      private_repo: ${{ env.PRIVATE_REPO }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    setup-matrix:
+        runs-on: ubuntu-latest
+        outputs:
+            php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
+            matrix: ${{ steps.set-matrix.outputs.matrix }}
+            private_repo: ${{ env.PRIVATE_REPO }}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
 
-      - name: Checkout reusable workflow repo
-        uses: actions/checkout@v4
+            - name: Checkout reusable workflow repo
+              uses: actions/checkout@v4
+              with:
+                  repository: pimcore/workflows-collection-public
+                  ref: main
+                  path: reusable-workflows
+
+            - name: Parse PHP versions from composer.json
+              id: parse-php-versions
+              run: |
+                  if [ -f composer.json ]; then
+                    php_versions=$(jq -r '.require.php' composer.json | grep -oP '\d+\.\d+' | tr '\n' ',' | sed 's/,$//')
+                    if [ -z "$php_versions" ]; then
+                      echo "No PHP versions found in composer.json"
+                      echo "Setting default PHP value"
+                      echo "php_versions=default" >> $GITHUB_OUTPUT
+                    else
+                      echo "php_versions=$php_versions" >> $GITHUB_OUTPUT
+                      echo "#### php versions #### : $php_versions"
+                    fi
+                  else
+                    echo "composer.json not found"
+                    exit 1
+                  fi
+
+            - name: Set up matrix
+              id: set-matrix
+              run: |
+                  php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
+                  
+                  MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
+                  
+                  IFS=',' read -ra VERSIONS_ARRAY <<< "$php_versions"
+                  
+                  FILTERED_MATRIX_JSON=$(echo $MATRIX_JSON | jq --arg php_versions "$php_versions" '
+                  {
+                    matrix: [
+                      .configs[] |
+                      select(.php_version == $php_versions) |
+                      .matrix[]
+                    ]
+                  }')
+                  
+                  ENCODED_MATRIX_JSON=$(echo $FILTERED_MATRIX_JSON | jq -c .)
+                  
+                  echo "matrix=${ENCODED_MATRIX_JSON}" >> $GITHUB_OUTPUT
+
+    static-analysis:
+        needs: setup-matrix
+        strategy:
+            matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+        uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-centralized.yaml@main
         with:
-          repository: pimcore/workflows-collection-public
-          ref: main
-          path: reusable-workflows
-
-      - name: Parse PHP versions from composer.json
-        id: parse-php-versions
-        run: |
-          if [ -f composer.json ]; then
-            php_versions=$(jq -r '.require.php' composer.json | grep -oP '\d+\.\d+' | tr '\n' ',' | sed 's/,$//')
-            if [ -z "$php_versions" ]; then
-              echo "php_versions=default" >> "$GITHUB_OUTPUT"
-            else
-              echo "php_versions=$php_versions" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            exit 1
-          fi
-
-      - name: Set up matrix JSON
-        id: set-matrix
-        run: |
-          php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
-          MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
-          FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq --arg php_versions "$php_versions" '{ include: [ .configs[] | select(.php_version == $php_versions) | .matrix[] ] }')
-          ENCODED_MATRIX_JSON=$(echo "$FILTERED_MATRIX_JSON" | jq -c .)
-          echo "phpstan_matrix=$ENCODED_MATRIX_JSON" >> "$GITHUB_OUTPUT"
-
-  static-analysis:
-    needs: setup-matrix
-    uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-unified.yaml@main
-    with:
-      phpstan_matrix: ${{ needs.setup-matrix.outputs.phpstan_matrix }}
-      private_repo: ${{ needs.setup-matrix.outputs.private_repo }}
-      APP_ENV: test
-      PIMCORE_TEST: 1
-      REQUIRE_ADMIN_BUNDLE: "false"
-      COVERAGE: "none"
-    secrets:
-      SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
-      COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
-      PIMCORE_CI_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}
-      PIMCORE_CI_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_CI_ENCRYPTION_SECRET }}
-      PIMCORE_CI_PRODUCT_KEY: ${{ secrets.PIMCORE_CI_PRODUCT_KEY }}
+            APP_ENV: test
+            PIMCORE_TEST: 1
+            PRIVATE_REPO: ${{ needs.setup-matrix.outputs.private_repo}}
+            PHP_VERSION: ${{ matrix.matrix.php-version }}
+            SYMFONY: ${{ matrix.matrix.symfony }}
+            DEPENDENCIES: ${{ matrix.matrix.dependencies }}
+            EXPERIMENTAL: ${{ matrix.matrix.experimental }}
+            PIMCORE_VERSION: ${{ matrix.matrix.pimcore_version }}
+            COMPOSER_OPTIONS: ${{ matrix.matrix.composer_options }}
+        secrets:
+            SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
+            COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,11 +5,16 @@ on:
         -   cron: '0 3 * * 1,3,5'
     workflow_dispatch:
     push:
+        paths-ignore:
+            - 'doc/**'
+            - '**.md'
         branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
-            - "feature-*"
     pull_request:
+        paths-ignore:
+            - 'doc/**'
+            - '**.md'
         types: [ opened, synchronize, reopened ]
 
 
@@ -17,9 +22,14 @@ env:
     PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
     PRIVATE_REPO: ${{ github.event.repository.private }}
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    cancel-in-progress: true
+
 jobs:
     setup-matrix:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         outputs:
             php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
             matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,6 +11,7 @@ on:
         branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
+            - "feature-*"
     pull_request:
         paths-ignore:
             - 'doc/**'
@@ -23,13 +24,13 @@ env:
     PRIVATE_REPO: ${{ github.event.repository.private }}
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
 jobs:
     setup-matrix:
         runs-on: ubuntu-latest
-        timeout-minutes: 30
+        timeout-minutes: 60
         outputs:
             php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
             matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,95 +1,86 @@
 name: "Static analysis centralised"
 
 on:
-    schedule:
-        -   cron: '0 3 * * 1,3,5'
-    workflow_dispatch:
-    push:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
-            - "feature-*"
-    pull_request:
-        types: [ opened, synchronize, reopened ]
-
+  schedule:
+    - cron: '0 3 * * 1,3,5'
+  workflow_dispatch:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - 'doc/**'
+      - 'src/Resources/public/**'
+      - '**.md'
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - 'src/Resources/public/**'
+      - '**.md'
+    branches:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.x"
 
 env:
-    PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
-    PRIVATE_REPO: ${{ github.event.repository.private }}
+  PIMCORE_PROJECT_ROOT: ${{ github.workspace }}
+  PRIVATE_REPO: ${{ github.event.repository.private }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
-    setup-matrix:
-        runs-on: ubuntu-latest
-        outputs:
-            php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
-            matrix: ${{ steps.set-matrix.outputs.matrix }}
-            private_repo: ${{ env.PRIVATE_REPO }}
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      php_versions: ${{ steps.parse-php-versions.outputs.php_versions }}
+      phpstan_matrix: ${{ steps.set-matrix.outputs.phpstan_matrix }}
+      private_repo: ${{ env.PRIVATE_REPO }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Checkout reusable workflow repo
-              uses: actions/checkout@v4
-              with:
-                  repository: pimcore/workflows-collection-public
-                  ref: main
-                  path: reusable-workflows
-
-            - name: Parse PHP versions from composer.json
-              id: parse-php-versions
-              run: |
-                  if [ -f composer.json ]; then
-                    php_versions=$(jq -r '.require.php' composer.json | grep -oP '\d+\.\d+' | tr '\n' ',' | sed 's/,$//')
-                    if [ -z "$php_versions" ]; then
-                      echo "No PHP versions found in composer.json"
-                      echo "Setting default PHP value"
-                      echo "php_versions=default" >> $GITHUB_OUTPUT
-                    else
-                      echo "php_versions=$php_versions" >> $GITHUB_OUTPUT
-                      echo "#### php versions #### : $php_versions"
-                    fi
-                  else
-                    echo "composer.json not found"
-                    exit 1
-                  fi
-
-            - name: Set up matrix
-              id: set-matrix
-              run: |
-                  php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
-                  
-                  MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
-                  
-                  IFS=',' read -ra VERSIONS_ARRAY <<< "$php_versions"
-                  
-                  FILTERED_MATRIX_JSON=$(echo $MATRIX_JSON | jq --arg php_versions "$php_versions" '
-                  {
-                    matrix: [
-                      .configs[] |
-                      select(.php_version == $php_versions) |
-                      .matrix[]
-                    ]
-                  }')
-                  
-                  ENCODED_MATRIX_JSON=$(echo $FILTERED_MATRIX_JSON | jq -c .)
-                  
-                  echo "matrix=${ENCODED_MATRIX_JSON}" >> $GITHUB_OUTPUT
-
-    static-analysis:
-        needs: setup-matrix
-        strategy:
-            matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
-        uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-centralized.yaml@main
+      - name: Checkout reusable workflow repo
+        uses: actions/checkout@v4
         with:
-            APP_ENV: test
-            PIMCORE_TEST: 1
-            PRIVATE_REPO: ${{ needs.setup-matrix.outputs.private_repo}}
-            PHP_VERSION: ${{ matrix.matrix.php-version }}
-            SYMFONY: ${{ matrix.matrix.symfony }}
-            DEPENDENCIES: ${{ matrix.matrix.dependencies }}
-            EXPERIMENTAL: ${{ matrix.matrix.experimental }}
-            PIMCORE_VERSION: ${{ matrix.matrix.pimcore_version }}
-            COMPOSER_OPTIONS: ${{ matrix.matrix.composer_options }}
-        secrets:
-            SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
-            COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
+          repository: pimcore/workflows-collection-public
+          ref: main
+          path: reusable-workflows
+
+      - name: Parse PHP versions from composer.json
+        id: parse-php-versions
+        run: |
+          if [ -f composer.json ]; then
+            php_versions=$(jq -r '.require.php' composer.json | grep -oP '\d+\.\d+' | tr '\n' ',' | sed 's/,$//')
+            if [ -z "$php_versions" ]; then
+              echo "php_versions=default" >> "$GITHUB_OUTPUT"
+            else
+              echo "php_versions=$php_versions" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            exit 1
+          fi
+
+      - name: Set up matrix JSON
+        id: set-matrix
+        run: |
+          php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
+          MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
+          FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq --arg php_versions "$php_versions" '{ include: [ .configs[] | select(.php_version == $php_versions) | .matrix[] ] }')
+          ENCODED_MATRIX_JSON=$(echo "$FILTERED_MATRIX_JSON" | jq -c .)
+          echo "phpstan_matrix=$ENCODED_MATRIX_JSON" >> "$GITHUB_OUTPUT"
+
+  static-analysis:
+    needs: setup-matrix
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-unified.yaml@main
+    with:
+      phpstan_matrix: ${{ needs.setup-matrix.outputs.phpstan_matrix }}
+      private_repo: ${{ needs.setup-matrix.outputs.private_repo }}
+      APP_ENV: test
+      PIMCORE_TEST: 1
+      REQUIRE_ADMIN_BUNDLE: "false"
+      COVERAGE: "none"
+    secrets:
+      SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER: ${{ secrets.SSH_PRIVATE_KEY_PIMCORE_DEPLOYMENTS_USER }}
+      COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN: ${{ secrets.COMPOSER_PIMCORE_REPO_PACKAGIST_TOKEN }}
+      PIMCORE_CI_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_CI_INSTANCE_IDENTIFIER }}
+      PIMCORE_CI_ENCRYPTION_SECRET: ${{ secrets.PIMCORE_CI_ENCRYPTION_SECRET }}
+      PIMCORE_CI_PRODUCT_KEY: ${{ secrets.PIMCORE_CI_PRODUCT_KEY }}


### PR DESCRIPTION
This PR now carries only trigger hygiene for `5.2` (pimcore/DevOps-Tasks#44 ideas 1–2): `php-style.yml` ran `on: [push]` — every push to every branch — now scoped to version branches with a concurrency group.

**Scope note:** the static-analysis repoint originally in this PR was reverted: `5.2` (`pimcore/pimcore ^11.2 || ^12.0`, PHP key 8.2,8.3,8.4) cannot install its 8.2/lowest leg — Pimcore 11 releases are blocked by the Composer advisory policy and Pimcore 12 needs PHP 8.3+. The repoint landed on `6.0` instead: pimcore/output-data-config-toolkit#167. The 5.2 static-analysis state is documented on pimcore/DevOps-Tasks#47.